### PR TITLE
a vida volta a 100 quando o jogador morre

### DIFF
--- a/src/Scenes/Jogo/eventosJogo.c
+++ b/src/Scenes/Jogo/eventosJogo.c
@@ -51,6 +51,7 @@ void eventosJogo(State *state)
 		if (state->jogoAtual.jogador.vida <= 0)
 		{
 			state->sceneAtual = GameOver;
+			state->jogoAtual.jogador.vida = state->jogoAtual.jogador.vidaMaxima;
 		}
 		
 		break;

--- a/src/state.c
+++ b/src/state.c
@@ -50,6 +50,7 @@ State criarEstado(int colunas, int linhas)
 	state.controloMenu.help = 0;
 
 	state.jogoAtual.jogador.vida = 100;
+	state.jogoAtual.jogador.vidaMaxima = 100;
 	state.jogoAtual.jogador.username = NULL;
 	state.jogoAtual.jogador.posicao.x = 3;
 	state.jogoAtual.jogador.posicao.y = 3;

--- a/src/state.h
+++ b/src/state.h
@@ -85,7 +85,8 @@ typedef struct statusJogador
 {
 	Coordenadas posicao;
 	char *username;
-	int vida; // valor entre 0 e 100
+	int vida; // valor entre 0 e ...
+	int vidaMaxima; // vida máxima do jogador
 	Arma armaPrincipal;
 	Arma armaSecundaria;
 	int dinheiro;


### PR DESCRIPTION
Mudado o state.h, struct do estado do jogador:
- há mais um parâmetro: vidaMaxima. Isto permite ampliar a vida quando se vão tomando poções e, quando o jogador morre, nesse mesmo save, volta-se a encher a vida, ficando com esse valor.
state.c:
- a vida máxima tem um valor inicial de 100
eventosjogo.c:
- quando a vida é 0 e aparece o game over, a vida é reiniciada.